### PR TITLE
Added support for switching OS without flashing

### DIFF
--- a/features/select_word.h
+++ b/features/select_word.h
@@ -30,6 +30,11 @@
  * default. Uncomment the `#define MAC_HOTKEYS` line in select_word.c for Mac
  * hotkeys. The Mac implementation is untested, let me know if it has problems.
  *
+ * @note Added support for using CG_TOGG to toggle between Mac and Win/Linux mode,
+ * removing the need to change the source, compile, and flash new firmware when
+ * switching OS. For documentation on CG_TOGG, see
+ * <https://docs.qmk.fm/#/keycodes_magic>
+ *
  * For full documentation, see
  * <https://getreuer.info/posts/keyboards/select-word>
  */
@@ -44,7 +49,7 @@ extern "C" {
 
 /** Handler function for select word. */
 bool process_select_word(uint16_t keycode, keyrecord_t* record,
-                         uint16_t sel_keycode);
+                         uint16_t sel_keycode, bool isMac);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
As the title states.

I read your post on the select word macro and noticed that in order to swap between OS', which I regularly do, I would have to comment/uncomment the line `#define MAC_HOTKEYS`, compile, and flash the new firmware each time. To mitigate that I extended your `process_select_word` function to pass an additional boolean argument.

To use this you have to will have to define a function that returns the value of `keymap_config.swap_lctl_lgui`, or just pass the value itself, in your keymap.c. Switching between modes is easily handled by mapping the keycode [CG_TOGG](https://docs.qmk.fm/#/keycodes_magic) to a key and toggling when needed, without having to compile and flash new firmware each time.