### PR TITLE
Add support for retro tapping

### DIFF
--- a/features/achordion.c
+++ b/features/achordion.c
@@ -131,8 +131,15 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
   }
 
   if (keycode == tap_hold_keycode && !record->event.pressed) {
+#ifdef RETRO_TAPPING
+    bool is_retro_key = IS_QK_MOD_TAP(keycode) || IS_QK_LAYER_TAP(keycode);
+#elif defined(RETRO_TAPPING_PER_KEY)
+    bool is_retro_key = get_retro_tapping(keycode, record);
+#else
+    bool is_retro_key = false;
+#endif
     // The active tap-hold key is being released.
-    if (achordion_state == STATE_HOLDING) {
+    if (achordion_state == STATE_HOLDING || is_retro_key) {
       dprintln("Achordion: Key released. Plumbing hold release.");
       tap_hold_record.event.pressed = false;
       // Plumb hold release event.
@@ -254,6 +261,12 @@ __attribute__((weak)) bool achordion_eager_mod(uint8_t mod) {
 #ifdef ACHORDION_STREAK
 __attribute__((weak)) uint16_t achordion_streak_timeout(uint16_t tap_hold_keycode) {
   return 100;  // Default of 100 ms.
+}
+#endif
+
+#ifdef RETRO_TAPPING_PER_KEY
+__attribute__((weak)) bool get_retro_tapping(uint16_t keycode, keyrecord_t *record) {
+    return false;
 }
 #endif
 


### PR DESCRIPTION
I tried to add retro tapping support to fix https://github.com/getreuer/qmk-keymap/issues/51

When a retro key is released during the state is `UNSETTLED`, Achordion doesn't do any plumbing back and as a result the retro key is not sent. 

- If retro tapping is enabled, the code checks whether the key is a mod tap or a layer tap key. This is the same as the definition of the `IS_RETRO()` macro defined in `process_auto_shift.h` but I didn't want to include that file just to be able to access this easy check. If necessary, I can include that file and use the `IS_RETRO()` macro instead of the manual layer tap / mod tap check.
- If per key retro tapping is enabled the code checks for the function that should have been defined in a user's `keymap.c` to check if retro tapping is enabled for the key. If the function not defined the weak overload (tried to mimic other functions above) returns false by default. 

If the key is determined to be a retro key, we do the same plumbing as when the state is settled to be `HOLDING` and the retro key is sent correctly.