### PR TITLE
Add retro tapping support

### DIFF
--- a/features/achordion.c
+++ b/features/achordion.c
@@ -35,6 +35,8 @@ static uint16_t tap_hold_keycode = KC_NO;
 static uint16_t hold_timer = 0;
 // Eagerly applied mods, if any.
 static uint8_t eager_mods = 0;
+// Flag to determine whether another key is pressed within the timeout.
+static bool pressed_another_key_before_release = false;
 
 #ifdef ACHORDION_STREAK
 // Timer for typing streak
@@ -87,6 +89,14 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
     return true;
   }
 
+  // If this is a keypress and if the key is different than the tap-hold key,
+  // this information is saved to a flag to be processed later when the tap-hold
+  // key is released.
+  if (!pressed_another_key_before_release && record->event.pressed &&
+      tap_hold_keycode != KC_NO && tap_hold_keycode != keycode) {
+    pressed_another_key_before_release = true;
+  }
+
   // Determine whether the current event is for a mod-tap or layer-tap key.
   const bool is_mt = IS_QK_MOD_TAP(keycode);
   const bool is_tap_hold = is_mt || IS_QK_LAYER_TAP(keycode);
@@ -131,16 +141,18 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
   }
 
   if (keycode == tap_hold_keycode && !record->event.pressed) {
-#ifdef RETRO_TAPPING
-    bool is_retro_key = IS_QK_MOD_TAP(keycode) || IS_QK_LAYER_TAP(keycode);
-#elif defined(RETRO_TAPPING_PER_KEY)
-    bool is_retro_key = get_retro_tapping(keycode, record);
-#else
-    bool is_retro_key = false;
-#endif
     // The active tap-hold key is being released.
-    if (achordion_state == STATE_HOLDING || is_retro_key) {
+    if (achordion_state == STATE_HOLDING) {
       dprintln("Achordion: Key released. Plumbing hold release.");
+      tap_hold_record.event.pressed = false;
+      // Plumb hold release event.
+      recursively_process_record(&tap_hold_record, STATE_RELEASED);
+    } else if (!pressed_another_key_before_release) {
+      // No other key was pressed between the press and release of the tap-hold
+      // key, simulate a hold and then a release without waiting for Achordion
+      // timeout to end.
+      dprintln("Achordion: Key released. Simulating hold and release.");
+      settle_as_hold();
       tap_hold_record.event.pressed = false;
       // Plumb hold release event.
       recursively_process_record(&tap_hold_record, STATE_RELEASED);
@@ -153,6 +165,9 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
     }
 
     achordion_state = STATE_RELEASED;
+    // The tap-hold key is released, clear the related keycode and the flag.
+    tap_hold_keycode = KC_NO;
+    pressed_another_key_before_release = false;
     return false;
   }
 

--- a/features/achordion.c
+++ b/features/achordion.c
@@ -279,10 +279,4 @@ __attribute__((weak)) uint16_t achordion_streak_timeout(uint16_t tap_hold_keycod
 }
 #endif
 
-#ifdef RETRO_TAPPING_PER_KEY
-__attribute__((weak)) bool get_retro_tapping(uint16_t keycode, keyrecord_t *record) {
-    return false;
-}
-#endif
-
 #endif  // version check

--- a/features/achordion.c
+++ b/features/achordion.c
@@ -131,8 +131,15 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
   }
 
   if (keycode == tap_hold_keycode && !record->event.pressed) {
+#ifdef RETRO_TAPPING
+    bool is_retro_key = IS_QK_MOD_TAP(keycode) || IS_QK_LAYER_TAP(keycode);
+#elif defined(RETRO_TAPPING_PER_KEY)
+    bool is_retro_key = get_retro_tapping(keycode, record);
+#else
+    bool is_retro_key = false;
+#endif
     // The active tap-hold key is being released.
-    if (achordion_state == STATE_HOLDING) {
+    if (achordion_state == STATE_HOLDING || is_retro_key) {
       dprintln("Achordion: Key released. Plumbing hold release.");
       tap_hold_record.event.pressed = false;
       // Plumb hold release event.
@@ -254,6 +261,12 @@ __attribute__((weak)) bool achordion_eager_mod(uint8_t mod) {
 #ifdef ACHORDION_STREAK
 __attribute__((weak)) uint16_t achordion_streak_timeout(uint16_t tap_hold_keycode) {
   return 100;  // Default of 100 ms.
+}
+#endif
+
+#ifdef RETRO_TAPPING_PER_KEY
+__attribute__((weak)) bool get_retro_tapping(uint16_t keycode, keyrecord_t *record) {
+    return false;
 }
 #endif
 


### PR DESCRIPTION
I tried to add support for features where a key is held and then released without pressing another key to fix https://github.com/getreuer/qmk-keymap/issues/51

In this PR, we try to circumvent the Achordion timeout if no other keypress happens between the press and release of the tap-hold key. When a tap-hold is pressed and released without the user pressing any other key in between, Achordion normally waits until the timeout finishes to settle the key as held and to send the events back to QMK to be processed. With this PR, If no other keypress happens until the tap-hold key is released, we simulate a hold and then release event to make Achordion play nice with these features.
