### PR TITLE
Change streak time to be based on tap-hold key

### DIFF
--- a/features/achordion.c
+++ b/features/achordion.c
@@ -175,7 +175,6 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
 #ifdef ACHORDION_STREAK
     const uint16_t s_timeout = achordion_streak_timeout(tap_hold_keycode, keycode);
     const bool is_streak = streak_timer && s_timeout && !timer_expired(record->event.time, (streak_timer + s_timeout));
-    streak_timer = record->event.time | 1;
 #endif
 
     // Press event occurred on a key other than the active tap-hold key.
@@ -213,10 +212,11 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
       // Plumb tap release event.
       recursively_process_record(&tap_hold_record, STATE_TAPPING);
 #ifdef ACHORDION_STREAK
+      streak_timer = record->event.time | 1;
       if (is_streak && is_key_event && is_tap_hold && record->tap.count == 0) {
         // If we are in a streak and resolved the current tap-hold key as a tap
         // consider the next tap-hold key as active to be resolved next.
-        streak_timer = tap_hold_record.event.time;
+        streak_timer = tap_hold_record.event.time | 1;
         const uint16_t timeout = achordion_timeout(keycode);
         tap_hold_keycode = keycode;
         tap_hold_record = *record;
@@ -234,7 +234,9 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
 
 #ifdef ACHORDION_STREAK
   // update idle timer on regular keys event
-  streak_timer = record->event.time | 1;
+  if (achordion_state != STATE_HOLDING) {
+    streak_timer = record->event.time | 1;
+  }
 #endif
   return true;
 }

--- a/features/achordion.c
+++ b/features/achordion.c
@@ -325,7 +325,7 @@ __attribute__((weak)) uint16_t achordion_streak_chord_timeout(uint16_t tap_hold_
 
 /** @deprecated Use `achordion_streak_chord_timeout()` instead. */
 __attribute__((weak)) uint16_t achordion_streak_timeout(uint16_t tap_hold_keycode) {
-  return 100;
+  return 200;
 }
 #endif
 

--- a/features/achordion.c
+++ b/features/achordion.c
@@ -258,7 +258,8 @@ void achordion_task(void) {
   }
 
 #ifdef ACHORDION_STREAK
-  if (streak_timer && timer_expired(timer_read(), (streak_timer + 800))) {
+  #define MAX_STREAK_TIMEOUT 800
+  if (streak_timer && timer_expired(timer_read(), (streak_timer + MAX_STREAK_TIMEOUT))) {
     streak_timer = 0;  // Expired.
   }
 #endif

--- a/features/achordion.c
+++ b/features/achordion.c
@@ -301,8 +301,8 @@ __attribute__((weak)) bool achordion_eager_mod(uint8_t mod) {
 
 #ifdef ACHORDION_STREAK
 __attribute__((weak)) bool achordion_streak_continue(uint16_t keycode) {
-  // If any mods other than shift are held, don't continue the streak
-  if (get_mods() & MOD_MASK_CAG) return false;
+  // If any mods other than shift or AltGr are held, don't continue the streak
+  if (get_mods() & (MOD_MASK_CG | MOD_BIT_LALT)) return false;
   // This function doesn't get called for holds, so convert to tap version of keycodes
   if (IS_QK_MOD_TAP(keycode)) keycode = QK_MOD_TAP_GET_TAP_KEYCODE(keycode);
   if (IS_QK_LAYER_TAP(keycode)) keycode = QK_LAYER_TAP_GET_TAP_KEYCODE(keycode);

--- a/features/achordion.c
+++ b/features/achordion.c
@@ -113,7 +113,7 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
       const uint16_t s_timeout = achordion_streak_timeout(keycode);
       // Apparently I don't know how timer_expired wortks. Can't get it to work here.
       //if (streak_timer && !timer_expired(record->event.time, streak_timer + 1900)) {
-      if (streak_timer && record->event.time < (streak_timer + s_timeout)) {
+      if (s_timeout && streak_timer && record->event.time < (streak_timer + s_timeout)) {
         // during a streak we immediately revise this as a tap
         dprintln("Achordion: Key pressed during streak. Plumbing tap.");
         tap_hold_keycode = keycode;

--- a/features/achordion.h
+++ b/features/achordion.h
@@ -66,8 +66,9 @@
  * Adjust the maximum time between key events before modifiers can be enabled
  * by defining the following callback in your keymap.c:
  *
- *    uint16_t achordion_streak_timeout(uint16_t tap_hold_keycode) {
- *      return 100;  // Default of 100 ms.
+ *    uint16_t achordion_streak_chord_timeout(
+ *        uint16_t tap_hold_keycode, uint16_t next_keycode) {
+ *      return 200;  // Default of 200 ms.
  *    }
  */
 #ifdef ACHORDION_STREAK

--- a/features/achordion.h
+++ b/features/achordion.h
@@ -71,7 +71,9 @@
  *    }
  */
 #ifdef ACHORDION_STREAK
-uint16_t achordion_streak_timeout(uint16_t tap_hold_keycode, uint16_t next_keycode);
+bool achordion_streak_continue(uint16_t keycode);
+uint16_t achordion_streak_chord_timeout(uint16_t tap_hold_keycode, uint16_t next_keycode);
+uint16_t achordion_streak_timeout(uint16_t tap_hold_keycode);
 #endif
 
 #ifdef __cplusplus

--- a/features/achordion.h
+++ b/features/achordion.h
@@ -71,7 +71,7 @@
  *    }
  */
 #ifdef ACHORDION_STREAK
-uint16_t achordion_streak_timeout(uint16_t tap_hold_keycode);
+uint16_t achordion_streak_timeout(uint16_t tap_hold_keycode, uint16_t next_keycode);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Based on my discussion in https://github.com/getreuer/qmk-keymap/discussions/59

This PR fixes a few issues with typing streak logic:
- The `achordion_streak_timeout` function was meant to be passed the tap_hold_keycode. Instead it was being passed the key pressed _before_ the tap-hold key. This made it impossible to use it to exempt a shift mod-tap key from the streak logic. This PR fixes that issue so that shift (or any other tap-hold key) can have different (or no) streak behavior now.
- It changes to use the time of the key event rather than `timer_read` to do the timings. ~~I think this makes things more accurate, as we don't process the key until after the initial tap-hold time has elapsed, so you needed much longer streak timeouts to be effective before.~~ I realized that the longer needed timeout times were because the original code was timing between the key before the tap-hold, and the key after the tap-hold (so a 2 key span.) I only realized this after I decided to (re)implement that behavior myself in this branch.
- If there were rolls on mod-tap keys during a streak (that evaluated to holds), previously only the first one would be converted to a tap by the streak logic. Now all of them will be converted to taps (if the subsequent ones are still within the streak timeout from the last.)
- Replace the `achordion_streak_timeout` function with `achordion_streak_chord_timeout` which is passed both the mod-tap key, and the key after (similar to `achordion_chord`.) This will allow exemption of combo keys outside of the normal letter area, e.g. alt-enter from the streak behavior. 
- Adds a separate function `achordion_streak_continue` to define which keys start (or continue) the typing streak logic. By default locks this to the main letter keys, punctuation and space with no modifiers held. This way streak logic doesn't intervene when you are moving around a document with navigation keys in combination with something like copying, pasting, or using emacs.
- ~~Makes sure quick hold sequences don't count towards streaks. e.g. the first keyup of the 'v' key in this combo would previously count toward a streak, and cause the second paste to not work: `ctrl-v,ctrl-v`~~ Rather than hard code this, I added logic to the default implementation of `achordion_streak_continue` to not count any keys pressed while a non-shift modifier is held toward a streak.

Notes/issues with this implementation:
- Since the streak timeout callback is only called after the delay, there is a hard coded 800ms cap on streak timeout right now. That could be lengthened or changed to be user configurable if needed.
- If multiple mod-tap keys are evaluated as holds in a row (within the streak timeout limits) all of the keydown events will be converted to tap events. However (I think) only the last keyup event will be converted to a tap event. I haven't experienced any issues with this in practice so far, but I don't know if there might be any hidden issues. Any ideas for a proper solution would be welcomed.
- I have some repeated code where it accepts the next tap-hold key as unsettled during a streak. I'm sure there is a way to clean that up, but I didn't find it yet.

I'm also wondering if it would be useful to have the key _before_ the tap-hold key when making the decision as well. Perhaps exempting something like arrow keys or backspace would make sense, to allow e.g. right, right, ctrl-v or backspace, ctrl-v.

~~This alters the behavior of how streaks work. Instead of each key being able to define a timeout needed after that key was pressed, each tap hold key can define the timeout needed before it was pressed. The main goal is to be able to shorten the streak timeout for shift, while keeping it long for other mod tap keys.~~

~~I think there are some small bugs with this though, perhaps to do with my misunderstanding of how timers work. Occasionally keys get resolved as taps due to being in a streak, even when no keys have been pressed recently. Maybe because the timer resets itself?~~

~~Mostly just looking for feedback on this alternative method, maybe some help fixing the small bugs left in this implementation.~~